### PR TITLE
Issue Templatesの追加

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,57 @@
+name: バグ報告
+description: アプリケーションのバグを報告
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        バグの報告ありがとうございます。以下の情報を記入してください。
+
+  - type: textarea
+    id: description
+    attributes:
+      label: バグの説明
+      description: バグの内容を簡潔に説明してください
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: 再現手順
+      description: バグを再現する手順を記載してください
+      placeholder: |
+        1. '...' に移動
+        2. '....' をクリック
+        3. '....' までスクロール
+        4. エラーを確認
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期待される動作
+      description: 正常な場合、どのような動作が期待されますか？
+    validations:
+      required: true
+
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: 使用ブラウザ
+      multiple: true
+      options:
+        - Chrome
+        - Firefox
+        - Safari
+        - Edge
+        - その他
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: 補足情報
+      description: スクリーンショットや追加情報があれば記載してください

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,50 @@
+name: ドキュメント更新
+description: ドキュメントの追加・修正
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ドキュメントの改善提案ありがとうございます。以下の情報を記入してください。
+
+  - type: input
+    id: target
+    attributes:
+      label: 対象ドキュメント
+      description: 更新が必要なドキュメントのパスや名称
+    validations:
+      required: true
+
+  - type: dropdown
+    id: type
+    attributes:
+      label: 更新の種類
+      options:
+        - 新規追加
+        - 既存の修正
+        - 削除
+        - リファクタリング
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: 更新内容
+      description: どのような更新が必要か説明してください
+    validations:
+      required: true
+
+  - type: textarea
+    id: reason
+    attributes:
+      label: 更新の理由
+      description: なぜこの更新が必要か説明してください
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: 補足情報
+      description: 参考情報や関連情報があれば記載してください

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,47 @@
+name: 機能要望
+description: 新機能のリクエスト
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        機能の提案ありがとうございます。以下の情報を記入してください。
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: 解決したい課題
+      description: この機能で解決したい問題や課題を説明してください
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: 提案する解決策
+      description: どのような機能があれば課題が解決できますか？
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: 優先度
+      options:
+        - 高（すぐに必要）
+        - 中（あれば便利）
+        - 低（将来的に）
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: 代替案
+      description: 他に検討した解決策があれば記載してください
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: 補足情報
+      description: スクリーンショットや参考情報があれば記載してください


### PR DESCRIPTION
## 概要
Issue Templatesを実装

## 変更内容
- バグ報告用テンプレート追加
- 機能要望用テンプレート追加
- ドキュメント更新用テンプレート追加

## 関連Issue
Closes #1